### PR TITLE
Use ghcr images for heplify-server and homer-app instead of dockerhub

### DIFF
--- a/charts/sipcapture/values.yaml
+++ b/charts/sipcapture/values.yaml
@@ -3,13 +3,13 @@ grafana:
   hostname:
   storage: 2Gi
 heplifyServer: 
-  image: sipcapture/heplify-server:master
+  image: ghcr.io/sipcapture/heplify-server:latest
 influxdb: 
   image: influxdb:1.8
   loglevel: info
   storage: 10Gi
 homer: 
-  image: sipcapture/webapp:latest
+  image: ghcr.io/sipcapture/homer-app:latest
   hostname:
 postgres: 
   image: postgres:11-alpine


### PR DESCRIPTION
Reference:-

https://github.com/sipcapture/heplify-server/issues/514#issuecomment-1550159800
https://github.com/sipcapture/homer-app/issues/472#issuecomment-1550128156